### PR TITLE
Fix Windows detection in gulpfile

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -14,7 +14,7 @@ import replace from "gulp-replace";
 import cssnano from "cssnano";
 
 const browserSync = BrowserSync.create();
-const hugoBin = `./bin/hugo.${process.platform === "windows" ? "exe" : process.platform}`;
+const hugoBin = `./bin/hugo.${process.platform === "win32" ? "exe" : process.platform}`;
 const defaultArgs = ["-d", "../dist", "-s", "site"];
 
 gulp.task("hugo", (cb) => buildSite(cb));


### PR DESCRIPTION
Both `npm start` and `yarn start` currently fail on Windows, as described in this [Stack Overflow question](https://stackoverflow.com/questions/43006845/netlify-cms-gulpe-server-error-due-to-missing-bin-hugo-win32-file).

Changing the `process.platform` conditional to match the [documented string for Windows](https://nodejs.org/api/os.html#os_os_platform) fixes the error.